### PR TITLE
Update parse_trans dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,3 @@
 {deps, [
-  {parse_trans, "2.5.5", {git, "https://github.com/esl/parse_trans.git", {tag, "2.5.5"}}}
+  {parse_trans, "3.1.0", {git, "https://github.com/uwiger/parse_trans.git", {tag, "3.1.0"}}}
 ]}.


### PR DESCRIPTION
So, it can compile.
Otherwise it gives me this error in edown:

```bash
==> edown (compile)
/home/user/erlang/arc/xapian-erlang-bindings/deps/edown/src/edown_doclet.erl:116: field packages undefined in record doclet_gen
/home/user/erlang/arc/xapian-erlang-bindings/deps/edown/src/edown_doclet.erl:118: field filemap undefined in record doclet_gen
Compiling /home/user/erlang/arc/xapian-erlang-bindings/deps/edown/src/edown_doclet.erl failed:
ERROR: compile failed while processing /home/user/erlang/arc/xapian-erlang-bindings/deps/edown: rebar_abort
```